### PR TITLE
SQMAGOPC-119 Remove unnecessary require of php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,6 @@
       "role": "Developer"
     }
   ],
-  "require": {
-    "php": "~7.1.3|~7.2.0"
-  },
   "type": "magento2-module",
   "version": "1.0.1",
   "license": "MIT",


### PR DESCRIPTION
Before: 
WARNING - "op-payment-service-for-magento-2.zip": It is not recommended to specify supported php versions in dependencies. If specified, it must at least match the php requirements of the supported Magento versions.

After:
DEBUG - "op-payment-service-for-magento-2.zip": Success, passed all the validation checks.